### PR TITLE
update context recall

### DIFF
--- a/rageval/metrics/_context_recall.py
+++ b/rageval/metrics/_context_recall.py
@@ -59,7 +59,7 @@ class ContextRecall(MetricWithLLM):
                 data = {'reasoning': reasonings, 'score': scores}
                 results.append(pd.DataFrame(data))
             else:
-                data = {'reasoning': [], 'score': [np.nan]}
+                data = {'reasoning': [np.nan], 'score': [np.nan]}
                 results.append(pd.DataFrame(data))
         df = pd.concat(results)
         return df
@@ -86,4 +86,5 @@ class ContextRecall(MetricWithLLM):
 
         result = self.llm.generate(prompts)
         result = self.parse_llm_result(prompts, result)
-        return result['score'].mean(), result
+        average_score = result['score'].mean() if not np.isnan(result['score'].mean()) else 0
+        return average_score, result

--- a/tests/units/test_context_recall.py
+++ b/tests/units/test_context_recall.py
@@ -7,7 +7,7 @@ import pytest
 import pandas as pd
 from datasets import Dataset
 from langchain.llms.fake import FakeListLLM
-
+from rageval.models.openai import OpenAILLM
 from rageval.metrics import ContextRecall
 
 
@@ -25,10 +25,28 @@ def testset(sample):
     ds = Dataset.from_dict(sample)
     return ds
 
-@pytest.mark.slow
+@pytest.mark.skip
 def test_batch_on_context_recall_metric(testset):
     metric = ContextRecall()
+    model = OpenAILLM('gpt-3.5-turbo-16k', 'OPENAI_API_KEY')
+    metric.init_model(model)
+    results = metric._score_batch(testset)
+    assert results[0] == 0 or results[0] == 1
+    assert isinstance(results[1], pd.DataFrame)
+
+@pytest.mark.slow
+def test_batch_on_context_recall_metric_fakellm1(testset):
+    metric = ContextRecall()
     model = FakeListLLM(responses=['[\n    {\n        "statement_1":"恐龙的命名始于1841年，由英国科学家理查德·欧文命名。",\n        "reason": "The answer provides the exact year and the scientist who named the dinosaurs.",\n        "Attributed": "1"\n    },\n    {\n        "statement_2":"欧文在研究几块样子像蜥蜴骨头化石时，认为它们是某种史前动物留下来的，并命名为恐龙。",\n        "reason": "The answer accurately describes the process of how dinosaurs were named.",\n        "Attributed": "1"\n    }\n]'])
+    metric.init_model(model)
+    results = metric._score_batch(testset)
+    assert results[0] >= 0 and results[0] <= 1
+    assert isinstance(results[1], pd.DataFrame)
+
+@pytest.mark.slow
+def test_batch_on_context_recall_metric_fakellm2(testset):
+    metric = ContextRecall()
+    model = FakeListLLM(responses=['wrong response format'])
     metric.init_model(model)
     results = metric._score_batch(testset)
     assert results[0] >= 0 and results[0] <= 1


### PR DESCRIPTION
- restore test for openai context recall (skipped in make test)
- add another fakellm test when llm reponse does not match required dict format
- fix bug in context recall metric 