### PR TITLE
add alce eli5 benchmark

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ dist/*
 .pytest_cache/
 .cache
 htmlcov/*
+.rageval/

--- a/README.md
+++ b/README.md
@@ -17,11 +17,12 @@ The generate task is to answer the question based on the contexts provided by re
 (1) **Answer Correctness**: this category of metrics is to evaluate the correctness by comparing the generated answer with the groundtruth answer. Here are some commonly used metrics:
 
 * [Answer NLI Correctness](./rageval/metrics/_answer_claim_recall.py): also known as *claim recall* in [the paper (Tianyu et al.)](https://arxiv.org/abs/2305.14627).
-* [Answer EM Correctness](./rageval/metrics/_answer_claim_recall.py): also known as *Exact Match* as used in the [ASQA paper (Ivan Stelmakh et al.)](https://arxiv.org/abs/2204.06092).
+* [Answer EM Correctness](./rageval/metrics/_answer_exact_match.py): also known as *Exact Match* as used in the [ASQA paper (Ivan Stelmakh et al.)](https://arxiv.org/abs/2204.06092).
 
 (2) **Answer Groundedness**: this category of metrics is to evaluate the groundedness (also known as factual consistency) by comparing the generated answer with the provided contexts. Here are some commonly used metrics:
-* ~~answer_citation_precision ("answer_citation_precision")~~
-* ~~answer_citation_recall ("answer_citation_recall")~~
+
+* [Answer Citation Precision](./rageval/metrics/_answer_citation_precision.py): also known as *citation precision* in [the paper (Tianyu et al.)](https://arxiv.org/abs/2305.14627).
+* [Answer Citation Recall](./rageval/metrics/_answer_citation_recall.py): also known as *citation recall* in [the paper (Tianyu et al.)](https://arxiv.org/abs/2305.14627).
 
 ### 2. [The rewrite task](./rageval/tasks/_rewrite.py)
 The rewrite task is to reformulate user question into a set of queries, making them more friendly to the search module in RAG. 

--- a/benchmarks/ALCE/ELI5/eli5.py
+++ b/benchmarks/ALCE/ELI5/eli5.py
@@ -1,0 +1,152 @@
+import json
+import os
+import time
+
+from datasets import Dataset
+from tqdm import tqdm
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+import rageval as rl
+from rageval.models.openai import OpenAILLM
+from utils import make_demo, create_eli5_eval_dataset
+
+
+class ELI5:
+
+    def __init__(self, args):
+        self.args = args
+
+        print("-" * 10 + "Loading model" + "-" * 10)
+        if "gpt-3.5-turbo" in self.args.model:
+            os.environ["OPENAI_API_KEY"] = self.args.api_key
+            self.model = OpenAILLM(
+                model=self.args.model,
+                _api_key_env_var="OPENAI_API_KEY",
+                max_tokens=self.args.max_tokens,
+                temperature=self.args.temperature,
+                top_p=self.args.top_p
+            )
+        else:
+            self.tokenizer = AutoTokenizer.from_pretrained(self.args.model, use_fast=False)
+            self.model = AutoModelForCausalLM.from_pretrained(
+                self.args.model,
+                device_map='auto'
+            )
+        print("-" * 10 + "Finish loading model" + "-" * 10)
+
+        print("-" * 10 + "Loading dataset" + "-" * 10)
+        if self.args.dataset == "bm25":
+            self.eval_data = json.load(
+                open(self.args.cache_path + "/datasets/ALCE-data/eli5_eval_bm25_top100.json", "r")
+            )
+        elif self.args.dataset == "oracle":
+            self.eval_data = json.load(
+                open(self.args.cache_path + "/datasets/ALCE-data/eli5_eval_bm25_top100_reranked_oracle.json", "r")
+            )
+        else:
+            raise ValueError("Don't support such dataset.")
+
+        self.prompt = json.load(
+            open("benchmarks/ALCE/ELI5/prompts/eli5_prompt.json", "r")
+        )
+        print("-" * 10 + "Finish loading dataset" + "-" * 10)
+
+        model_name = self.args.model
+        if "/" in model_name:
+            model_name = model_name.split("/")[-1]
+        self.name = f"eli5-{self.args.dataset}-{model_name}-{self.args.method}-shot{self.args.shot}-ndoc{self.args.ndoc}"
+        self.result_path = ".rageval/results/" + self.name + ".json"
+
+    def generate(self):
+        head_prompt = ""
+        for demo_id in range(self.args.shot):
+            demo_item = self.prompt["demos"][demo_id]
+            prompt, _ = make_demo(
+                demo_item,
+                prompt=self.prompt["demo_prompt"],
+                ndoc=self.args.ndoc,
+                doc_prompt=self.prompt["doc_prompt"],
+                instruction=self.prompt["instruction"],
+                method=self.args.method
+            )
+            head_prompt += prompt
+            head_prompt += self.prompt["demo_sep"]
+
+        print("-" * 10 + "Generating prompts" + "-" * 10)
+        for idx, eval_item in enumerate(tqdm(self.eval_data)):
+            prompt, doc_texts = make_demo(
+                eval_item,
+                prompt=self.prompt["demo_prompt"],
+                ndoc=self.args.ndoc,
+                doc_prompt=self.prompt["doc_prompt"],
+                instruction=self.prompt["instruction"],
+                method=self.args.method,
+                test=True
+            )
+            self.eval_data[idx]['prompt'] = head_prompt + prompt
+            self.eval_data[idx]['contexts'] = doc_texts
+            self.eval_data[idx]['docs'] = eval_item["docs"][:self.args.ndoc]
+        print("-" * 10 + "Finish generating prompts" + "-" * 10)
+
+        for idx, item in enumerate(tqdm(self.eval_data)):
+            prompt = item['prompt']
+            if "gpt-3.5-turbo" in self.args.model:
+                output = self.model.generate(
+                    [prompt],
+                    "You are a helpful assistant that answers the following questions with proper citations."
+                )
+                item['output'] = output.generations[0][0].text
+            else:
+                inputs = self.tokenizer([prompt], return_tensors="pt").to(self.model.device)
+                stop = ["\n", "Ċ", "ĊĊ", "<0x0A>"]  # In Llama \n is <0x0A>; In OPT \n is Ċ
+                stop_token_ids = list(
+                    set(
+                        [self.tokenizer._convert_token_to_id(stop_token) for stop_token in stop]
+                        + [self.model.config.eos_token_id]
+                    )
+                )
+                if "llama" in self.args.model.lower():
+                    stop_token_ids.remove(self.tokenizer.unk_token_id)
+
+                generation = self.model.generate(
+                    **inputs,
+                    max_length=self.args.max_length,
+                    temperature=self.args.temperature,
+                    top_p=self.args.top_p,
+                    eos_token_id=stop_token_ids,
+                    do_sample=True
+                )
+                output = self.tokenizer.decode(generation[0][inputs['input_ids'].size(1):], skip_special_tokens=True)
+                item['output'] = output
+
+        json.dump(self.eval_data, open(self.result_path, "w"), indent=4)
+
+    def evaluate(self):
+        dataset = Dataset.from_generator(create_eli5_eval_dataset, gen_kwargs={"result_path": self.result_path})
+        result = {}
+        nli_model = rl.models.NLIModel(
+            "text2text-generation",
+            self.args.cache_path + "/models/t5_xxl_true_nli_mixture",
+        )
+        if "nli_claim" in self.args.metrics:
+            metric = rl.metrics.AnswerNLICorrectness(nli_model=nli_model, decompose_model="nltk")
+            score, ds = metric.compute(dataset)
+            result["nli_claim"] = 100 * score
+
+        if "citation_recall" in self.args.metrics:
+            metric = rl.metrics.AnswerCitationRecall(nli_model=nli_model)
+            score, ds = metric.compute(dataset)
+            result["citation_recall"] = 100 * score
+
+        if "citation_precision" in self.args.metrics:
+            metric = rl.metrics.AnswerCitationPrecision(nli_model=nli_model)
+            score, ds = metric.compute(dataset)
+            result["citation_precision"] = 100 * score
+
+        date = time.strftime("%Y%m%d", time.localtime())
+
+        json.dump(
+            result,
+            open(f"benchmarks/ALCE/ELI5/results/{self.name}-{date}.json", "w"),
+            indent=4
+        )

--- a/benchmarks/ALCE/ELI5/prompts/eli5_prompt.json
+++ b/benchmarks/ALCE/ELI5/prompts/eli5_prompt.json
@@ -1,0 +1,152 @@
+{
+    "instruction": "Instruction: Write an accurate, engaging, and concise answer for the given question using only the provided search results (some of which might be irrelevant) and cite them properly. Use an unbiased and journalistic tone. Always cite for any factual claim. When citing several search results, use [1][2][3]. Cite at least one document and at most three documents in each sentence. If multiple documents support the sentence, only cite a minimum sufficient subset of the documents.",
+    "demo_sep": "\n\n\n",
+    "demo_prompt": "{INST}\n\nQuestion: {Q}\n\n{D}\nAnswer: {A}",
+    "doc_prompt": "Document [{ID}](Title: {T}): {P}\n",
+    "demos": [
+        {
+            "question": "Why did New York City try to ban food donations to the poor?",
+            "answer": "New York City, under Mayor Michael Bloomberg's administration, banned citizens from donating food directly to homeless shelters because the city could not assess the salt, fat, and fiber content [1][2][3]. Bloomberg's administration was heavily criticized for losing their common sense by becoming too focused on what people eat [2].",
+            "docs": [
+                {
+                    "title": "The Future Of America",
+                    "text": "believe that they are \u201chelping\u201d the homeless by passing such laws. In New York City, Mayor Bloomberg has banned citizens from donating food directly to homeless shelters and he is actually convinced that it was the right thing to do for the homeless\u2026 Mayor Michael Bloomberg\u2019s food police have struck again! Outlawed are food donations to homeless shelters because the city can\u2019t assess their salt, fat and fiber content, reports CBS 2\u2019s Marcia Kramer. Glenn Richter arrived at a West Side synagogue on Monday to collect surplus bagels \u2014 fresh nutritious bagels \u2014 to donate to the poor.",
+                    "summary": "Why did New York City try to ban food donations to the poor? - Mayor Bloomberg banned citizens from donating food directly to homeless shelters, claiming the city couldn't assess the salt, fat, and fiber content.",
+                    "extraction": "New York City tried to ban food donations to the poor because Mayor Bloomberg banned citizens from donating food directly to homeless shelters, as the city can't assess their salt, fat, and fiber content."
+                },
+                {
+                    "title": "mayor bloomberg",
+                    "text": "Amuck: Bloomberg Bans Food Donations in New York City Food Might Be Salty or Too High in Calories, City Explains Washington, D.C. \u2013 New York Mayor Michael Bloomberg\u2019s administration is now banning all food being offered to the city\u2019s homeless shelters. New York City\u2019s bureaucrats have become so singularly focused on what people eat, says the National Center for Public Policy Research, that they\u2019ve lost their common sense. \u201cSo much for serving the homeless: The Bloomberg administration is now taking the term \u2018food police\u2019 to new depths, blocking food donations to all government-run facilities that serve the",
+                    "summary": "New York City tried to ban food donations to the poor because Mayor Michael Bloomberg's administration was singularly focused on what people eat and believed that the food might be salty or too high in calories.",
+                    "extraction": "New York City tried to ban food donations to the poor because the Bloomberg administration is now blocking food donations to all government-run facilities that serve the homeless."
+                },
+                {
+                    "title": "New York City bans food donations - WND",
+                    "text": "New York City bans food donations - WND Front Page Health U.S. New York City bans food donations Inability to control 'nutritional content' cited as reason New York City homeless shelters have Mayor Michael Bloomberg to thank for a halt in food donations, for which hungry families are waiting, according to one public policy advocate. \"The Bloomberg administration is now taking the term 'food police' to new depths, blocking food donations to all government-run facilities that serve the city's homeless,\" says Jeff Stier, a National Center for Public Policy Research senior fellow. Currently, no food can be given to government-run, New York City facilities, despite hungry crowds perfectly",
+                    "summary": "New York City tried to ban food donations to government-run facilities serving the homeless because of an inability to control nutritional content, according to Mayor Michael Bloomberg. The ban was criticized by a public policy advocate and no food can be given to government-run facilities at present.",
+                    "extraction": "The New York City government tried to ban food donations to government-run facilities that serve the city's homeless because they were unable to control the nutritional content of the donated food."
+                },
+                {
+                    "title": "New York City bans food donations - WND",
+                    "text": "New York City bans food donations - WND Services didn't return WND calls. Stier told WND that he specifically was told by Diamond that the policy was tied to the nutritional guidelines set by the mayor. \"They can say that this ban on donations is a long-standing policy, but they can\u2019t document it,\" Stier told WND. \"I've also been told that there are numerous food shelves that have been accepting food donations, not just one.\" Stier is a member of a New York Synagogue that has donated food for over a decade. He is outraged that the DHS' response to his demand to know why the practice can",
+                    "summary": "New York City banned food donations, but the reason for the ban is unclear. The ban appears to be tied to nutritional guidelines set by the mayor, although the policy is not well-documented. A member of a New York synagogue that had donated food for over a decade is outraged by the ban.",
+                    "extraction": "The New York City tried to ban food donations to the poor because the policy was tied to the nutritional guidelines set by the mayor."
+                },
+                {
+                    "title": "New York City bans food donations - WND",
+                    "text": "New York City bans food donations - WND ban on donated food. In fact, it thrives because of food donations. New York City Rescue Mission has been providing food, clothing, shelter and spiritual hope for needy New Yorkers since 1872. \"We feed over 500 people a day, all through donations,\" said James Varnhagen, NYCRM director. \"Boxed food, canned food, prepared food, we take any food,\" he told WND. \"We couldn't survive without donations,\" he said.",
+                    "summary": "New York City tried to ban food donations to the poor, but the article argues that this ban is unnecessary and harmful, as many organizations rely on donations to provide for those in need.",
+                    "extraction": "New York City tried to ban food donations to the poor because of a regulation that requires any organization giving out food to the public to have a food service establishment permit."
+                }
+            ]
+        },
+        {
+            "question": "What's the difference between Shia vs. Sunni Islam?",
+            "answer": "The main difference between Shia and Sunni Muslim is related to ideological heritage and issues of leadership [1]. This difference is first formed after the death of the Prophet Muhammad in 632 A.D. [1][2]. The ideological practice of the Sunni branch strictly follows Prophet Muhammad and his teachings, while the Shia branch follows Prophet Muhammad's son-in-law Ali [2]. Nowadays, Sunni and Shia are the major branches of Islam [3].",
+            "docs": [
+                {
+                    "title": "The Sunni vs Shia Divide - Explained - Globaloi",
+                    "text": "centuries-long strained relationship between Sunnis and Shias. As a scholar of Islam and a public educator, I often field questions about Sunnis, Shias and the sects of Islam. What exactly is the Shia-Sunni divide? And what is its history? History of divide Both Sunnis and Shias \u2013 drawing their faith and practice from the Qur\u2019an and the life of the Prophet Muhammad \u2013 agree on most of the fundamentals of Islam. The differences are related more to historical events, ideological heritage and issues of leadership. The first and central difference emerged after the death of Prophet Muhammad in A.D. 632.",
+                    "summary": "The article explains the centuries-long strained relationship between Sunnis and Shias in Islam. The differences between the two groups are related to historical events, ideological heritage, and issues of leadership that emerged after the death of Prophet Muhammad in A.D. 632.",
+                    "extraction": "The Shia-Sunni divide is related more to historical events, ideological heritage and issues of leadership. The first and central difference emerged after the death of Prophet Muhammad in A.D. 632."
+                },
+                {
+                    "title": "What\u2019s the difference between Sunni and Shia Islam? \u2013 Macrosnaps",
+                    "text": "What\u2019s the difference between Sunni and Shia Islam? Sunni and Shia identities (the 2 main branches of Islam) first formed around a dispute over leadership succession after the death of the Prophet Muhammad in 632 A.D. Sunni is the larger branch (estimated 85-90% of total world Muslim population) and it's adherents are referred to as \"people of the tradition of Muhammad\", while Shia are \"followers\" of Muhammad's son-in-law and cousin Ali. Sunnis rely heavily on the practice of the Prophet Muhammad and his teachings, the Shia view their ayatollahs as reflections of God on earth. What challenges does the anti-IS",
+                    "summary": "Sunni and Shia Islam first formed around a dispute over leadership succession after the death of Prophet Muhammad in 632 AD. Sunni is the larger branch, estimated to be 85-90% of total world Muslim population, while Shia are followers of Muhammad's son-in-law and cousin Ali. Sunnis rely heavily on the practice and teachings of Prophet Muhammad, while the Shia view their ayatollahs as reflections of God on earth.",
+                    "extraction": "Sunni and Shia identities first formed around a dispute over leadership succession after the death of the Prophet Muhammad in 632 A.D. Sunni is the larger branch and it's adherents are referred to as \"people of the tradition of Muhammad\", while Shia are \"followers\" of Muhammad's son-in-law and cousin Ali."
+                },
+                {
+                    "title": "Difference between Sunni and Shia Muslims | Sunni vs Shia Muslims",
+                    "text": "of Muhammad, the last prophet of God. A follower of Islam is known as a Muslim. Many Muslims believe that their sole purpose is to worship and serve God, for which they have established five pillars of Islam that guides a Muslim on almost every aspect of life and society. Due to differences, Muslims have been divided into two primary sects: The Sunnis and the Shias. These two sects have many similarities and both consider themselves are Muslims, following the will of God. However, they are also different from each other in certain aspects. Both the Sunnis and the Shias,",
+                    "summary": "The document discusses the differences between Sunni and Shia Muslims, who are two primary sects of Islam. It explains that both consider themselves Muslims and follow the will of God, but they have differences in certain aspects. However, it does not provide any specific details about the differences.",
+                    "extraction": "The primary difference between Sunni and Shia Muslims is that they are divided into two sects. While both consider themselves Muslims and follow the will of God, they differ from each other in certain aspects."
+                },
+                {
+                    "title": "What is the difference between Shia and Sunni Islam? - Islam Stack Exchange",
+                    "text": "What is the difference between Shia and Sunni Islam? - Islam Stack Exchange between Mutah marriage and Misyar marriage? What theological and historical factors distinguish Ibadi Islam from either Shia or Sunni schools? What are the principle/fundamental differences between Sunni and Shia? Nikah between a Sunni girl and Shia boy What is the difference between \u201cMubtalat-of-Wudu\u201d of Shia and Sunni? How can the Hadith be reliable when Sunnis and Shia follow different points of reference? Rejection of Mutawatir Hadith in Sunni Islam and Shia Islam",
+                    "summary": "The document discusses the differences between Shia and Sunni Islam, including theological and historical factors, as well as questions about marriage and Hadith reliability. It does not provide specific dates, numbers or names.",
+                    "extraction": "The principle/fundamental differences between Sunni and Shia."
+                },
+                {
+                    "title": "What is the difference between Sunni and Shia Islam? | Patrick Syder Travel",
+                    "text": "What is the difference between Sunni and Shia Islam? | Patrick Syder Travel What is the difference between Sunni and Shia Islam? This Channel 4 link answers some of the key questions about the difference between Sunni and Shia Islam and alarmingly, the politics on what is happening and why, in Syria\u2026\u2026. http://www.channel4.com/news/sunni-shia-islam-muslim-syria-middle-east-key-questions \u2190 Ethiopia Appeal \u2013 Help sponsor a nurse to train and to help others G\u00f6bekli Tepe, Turkey: a new wonder of the ancient world by Jeremy Seal (Telegraph Travel Section 23/04/2013) \u2192",
+                    "summary": "The document is relevant to the question of interest \"What is the difference between Shia vs. Sunni Islam?\" but does not provide any useful information.",
+                    "extraction": "This Channel 4 link answers some of the key questions about the difference between Sunni and Shia Islam."
+                }
+            ]
+        },
+        {
+            "question": "What causes Bi-polar disorder?",
+            "answer": "Bipolar disorder is an emotional disorder that causes extreme mood swings between excitement and depression [1][3]. The spectrum of mood swing may span from days to months [1][2]. We are still not certain of the exact factors that cause such disorder, but genetics is considered a major factor [2][3].",
+            "docs": [
+                {
+                    "title": "Bi-polar disorder | definition of Bi-polar disorder by Medical dictionary",
+                    "text": "bi-polar disorder | definition of bi-polar disorder by medical dictionary https://medical-dictionary.thefreedictionary.com/bi-polar+disorder (redirected from bi-polar disorder) related to bi-polar disorder: depression bipolar disorder, formerly known as manic depression, is a mood disorder that causes radical emotional changes and mood swings, from manic, restless highs to depressive, listless lows. most bipolar individuals experience alternating episodes of mania and depression. bipolar disorder is characterized by alternating manic episodes in which the individual feels abnormally euphoric, optimistic, and energetic and depressive periods in which the individual feels sad, hopeless, guilty, and sometimes suicidal. manic or depressive periods may last for days, weeks, or months",
+                    "summary": "Bipolar disorder is a mood disorder that causes radical emotional changes and mood swings, from manic, restless highs to depressive, listless lows. The disorder is characterized by alternating manic episodes in which the individual feels abnormally euphoric, optimistic, and energetic and depressive periods in which the individual feels sad, hopeless, guilty, and sometimes suicidal. The document does not provide information on what causes bipolar disorder.",
+                    "extraction": "The passage states that Bi-polar disorder is a mood disorder that causes radical emotional changes and mood swings, from manic, restless highs to depressive, listless lows. It is characterized by alternating manic episodes in which the individual feels abnormally euphoric, optimistic, and energetic and depressive periods in which the individual feels sad, hopeless, guilty, and sometimes suicidal. However, it does not provide information on the causes of Bi-polar disorder. Therefore, the extracted span is \"irrelevant\"."
+                },
+                {
+                    "title": "Mania and Bi-Polar",
+                    "text": "can go from depressed to \u201csuper happy\u201d all in one day, or even in a few days, does not have a bi-polar disorder Bi-polar looks different depending on the severity of the symptoms. Most bi-polar diagnoses that are made are for bi-polar 2, with bi-polar 1 being much more rare. Bi-polar 1 is so severe that the individual will have periods of such agitation, or such reckless and seemingly foolish behavior that they put themselves or those around them in danger. It is not completely clear what causes bi-polar, but genetics seem to have a large role. The biggest factor",
+                    "summary": "Genetics seem to have a large role in causing bi-polar disorder, though it's unclear what exactly causes it. Bi-polar comes in different forms, with bi-polar 1 being more severe and rare.",
+                    "extraction": "It is not completely clear what causes bi-polar, but genetics seem to have a large role."
+                },
+                {
+                    "title": "Bi-Polar disorder",
+                    "text": "Bi-Polar disorder Bi-polar is generally a cyclic disease where individuals display depressive and elevated episodes at regular intervals. It is a disorder resulting from the imbalance of the chemicals in the brain that causes a lot of fluctuations of mood. It is a fact that we all experience happy and sad moods, but people with bi-polar disorder experience the changes in mood at an increased level. The cause of this disorder is not known completely. However, it is estimated that there are different factors responsible for it. It is often connected to a genetic component. People suffering from the Bi-polar disorder are",
+                    "summary": "The cause of Bi-Polar disorder is not fully known, but it is believed to be related to a genetic component and an imbalance of chemicals in the brain that cause mood fluctuations.",
+                    "extraction": "The cause of Bi-polar disorder is not known completely, but it is estimated that there are different factors responsible for it including a genetic component."
+                },
+                {
+                    "title": "For Individuals \u2014 Adam Schwartz",
+                    "text": "For Individuals \u2014 Adam Schwartz The information is extensive and covers a huge range of topics. Some of the topics include the different types of bi-polar, what it feels like, signs and symptoms, treatments and more. Black Dog Institute bi-polar causes resource specifically covers the variety of areas that could potentially be a cause of bi-polar disorder. Including genetics, environmental factors, pregnancy, and more. Black Dog Institute bi-polar treatments resource specifically covers multiple potential treatments options for bi-polar. Including management, types of psychological treatment, lifestyle changes, and more. Black Dog Institute bi-polar self-test resource is a short self-test for people who may be concerned if",
+                    "summary": "The Black Dog Institute has a resource on potential causes of bipolar disorder, including genetics and environmental factors, as well as treatments such as psychological treatment and lifestyle changes.",
+                    "extraction": "The Black Dog Institute bi-polar causes resource specifically covers the variety of areas that could potentially be a cause of bi-polar disorder, including genetics, environmental factors, pregnancy, and more."
+                },
+                {
+                    "title": "Depression Bi-polar Disorder Symptoms 2019 | Win Over Depression",
+                    "text": "Depression Bi-polar Disorder Symptoms 2019 | Win Over Depression signs and symptoms of bipolar disorder. Learn more about the common symptoms of bipolar depression that some patients may experience. Home \u00bb Trending Health News \u00bb 10 Warning Signs of Bipolar Disorder: Depression. One of the most serious symptoms of bipolar disorder is. Bi Polar Depression. SEVERE SWINGS What is bipolar disorder, is it the same as manic depression, what are the symptoms and is there a cure? Bipolar disorder, or manic depression, causes symptoms of mania and depression. Read about bipolar disorder treatment, medications, and causes of this. Learn more about the different types of bipolar disorder. Find out",
+                    "summary": "The document discusses the signs and symptoms of Bi-polar disorder and provides information about the different types and treatments available. However, it does not provide information about the causes of the disorder.",
+                    "extraction": "Bipolar disorder, or manic depression, causes symptoms of mania and depression."
+                }
+            ]
+        },
+        {
+            "question": "How do student loans affect getting a mortgage?",
+            "answer": "When applying for a mortgage, student loans can affect the debt to income ratio, which is a key factor in determining the amount that an individual can afford to pay for the mortgage [1]. While student loan repayments do not appear in an individual's credit history and do not affect credit scores, lenders do consider the amount of an individual's student loan repayments when assessing their mortgage application [1][2][3]. Some 83% of non-homeowners say student loan debt is preventing them from buying a home, according to the National Association of Realtors [2]. It is important to note that student loans do not prevent an individual from getting a mortgage [1].",
+            "docs": [
+                {
+                    "title": "Student Loans \u2013 How do they work? | The Financial Review",
+                    "text": "typical debt. Student loan repayments do not appear in an individual\u2019s credit history, therefore there are no implications whatsoever. This also extends to applications for credit cards \u2013 student \u2018loans\u2019 are not acknowledged. One noteworthy aspect that is affected by student loans however, is mortgage applications. Nevertheless, it does not prevent an individual from getting a mortgage. For example, lenders will consider the amount of an individual\u2019s student loan repayments in order to assess the debt to income ratio and therefore establish the amount that the individual can afford to pay for the mortgage. Just as they do with other",
+                    "summary": "Student loans are considered by lenders when assessing an individual's debt to income ratio for mortgage applications, but having student loans does not prevent someone from getting a mortgage. However, the article does not provide any specific dates, numbers, or names related to the topic.",
+                    "extraction": "Student loans do not prevent an individual from getting a mortgage. Lenders will consider the amount of an individual\u2019s student loan repayments in order to assess the debt to income ratio and therefore establish the amount that the individual can afford to pay for the mortgage."
+                },
+                {
+                    "title": "How Does Student Loan Debt Affect Buying a Home? | Experian",
+                    "text": "Rates & Affordability How Student Loans Affect Getting a Mortgage Student Loan Impact on Credit Scores Other Factors for Getting Approved for a Mortgage If you're a recent college grad and hope to become a homeowner in the near future, you should know that student loan debt could affect buying a home by making it more difficult to get a mortgage. Some 83% of non-homeowners say student loan debt is preventing them from buying a home, according to the National Association of Realtors (NAR). But while student loan payments can make it harder to save for a down payment on",
+                    "summary": "Student loan debt could make it more difficult to get a mortgage and 83% of non-homeowners say student loan debt is preventing them from buying a home, according to the National Association of Realtors.",
+                    "extraction": "Student loan debt could affect buying a home by making it more difficult to get a mortgage. Some 83% of non-homeowners say student loan debt is preventing them from buying a home."
+                },
+                {
+                    "title": "Studentloanify - How your student loans affect your home mortgage prospects",
+                    "text": "Though it may not seem fair, your student loan situation impacts your home mortgage outlook. Many people carry student loan debt, but it\u2019s the amount of the loan and how you handle your student loan repayment plan that will influence your ability to get a home mortgage as well as what your interest rate will be. Here are some specific factors about your student loan that will affect your home mortgage prospects. On your mortgage loan application, you will have to report how much your monthly student loan payment is. This amount will be deducted from your monthly gross income",
+                    "summary": "Your student loan situation impacts your home mortgage outlook. The amount of the loan and how you handle repayment affects your ability to get a mortgage and your interest rate. On your mortgage application, you report your monthly student loan payment which is deducted from your monthly gross income.",
+                    "extraction": "\"On your mortgage loan application, you will have to report how much your monthly student loan payment is. This amount will be deducted from your monthly gross income.\""
+                },
+                {
+                    "title": "How do student loans affect your credit score? | Student Loan Planner",
+                    "text": "How do student loans affect your credit score? | Student Loan Planner Your credit score is the three-digit number that dictates a lot in your adult life. Whether you\u2019re applying for a mortgage or looking to get an auto loan, this seemingly arbitrary number determines whether you get approved for a loan and also affects your interest rate. If you\u2019re a student loan borrower you may wonder, \u201cDo student loans affect credit score?\u201d You might be especially curious if you\u2019re in the process of applying for a mortgage. Here\u2019s how student loans affect your credit score and what to know for big life events, like getting a mortgage. Do student loans affect",
+                    "summary": "The document discusses how student loans affect credit scores and their impact on obtaining loans such as a mortgage.",
+                    "extraction": "Here’s how student loans affect your credit score and what to know for big life events, like getting a mortgage."
+                },
+                {
+                    "title": "Does Student Loan Debt Affect Getting A Mortgage?",
+                    "text": "Does Student Loan Debt Affect Getting A Mortgage? Home \u00bb Does Student Loan Debt Affect Getting A Mortgage? Last year, I helped answer a reader\u2019s question about applying for a mortgage while on Income Based Repayment. However, over the last several months, I\u2019ve been getting bombarded with questions about how student loan debt impacts your ability to get a mortgage. Maybe it\u2019s because the housing market is improving, or maybe it\u2019s because people are finally taking their student loan debt seriously. Anyway, I wanted to share a few reader questions and then look at whether student loan debt affects getting a mortgage. Here are the reader questions I\u2019ve",
+                    "summary": "The document discusses the impact of student loan debt on getting a mortgage. The author shares reader questions and explores whether student loan debt affects mortgage eligibility.",
+                    "extraction": "Student loan debt can impact a person's ability to get a mortgage."
+                }
+            ]
+        }
+    ]
+}

--- a/benchmarks/ALCE/ELI5/results/eli5-bm25-Llama-2-7b-chat-hf-vanilla-shot2-ndoc5-20240310.json
+++ b/benchmarks/ALCE/ELI5/results/eli5-bm25-Llama-2-7b-chat-hf-vanilla-shot2-ndoc5-20240310.json
@@ -1,0 +1,5 @@
+{
+    "nli_claim": 11.5,
+    "citation_recall": 26.623809523809523,
+    "citation_precision": 74.54545454545455
+}

--- a/benchmarks/ALCE/ELI5/run.py
+++ b/benchmarks/ALCE/ELI5/run.py
@@ -1,0 +1,23 @@
+import argparse
+
+from eli5 import ELI5
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--cache_path", type=str, default=None)
+    parser.add_argument("--model", type=str, default="gpt-3.5-turbo")  # openai model/local LLM
+    parser.add_argument("--api_key", type=str, default=None)  # api_key is necessary if using openai model
+    parser.add_argument("--max_length", type=int, default=4096)
+    parser.add_argument("--temperature", type=float, default=0.5)
+    parser.add_argument("--top_p", type=float, default=1.0)
+    parser.add_argument("--dataset", type=str, default="bm25")  # bm25/oracle
+    parser.add_argument("--method", type=str, default="vanilla")
+    parser.add_argument("--ndoc", type=int, default=5)
+    parser.add_argument("--shot", type=int, default=2)
+    parser.add_argument("--metrics", nargs="+", type=str, default=["nli_claim"])
+    args = parser.parse_args()
+
+    eli5 = ELI5(args)
+    eli5.generate()
+    eli5.evaluate()

--- a/benchmarks/ALCE/ELI5/run.py
+++ b/benchmarks/ALCE/ELI5/run.py
@@ -19,7 +19,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     eli5 = ELI5(args)
-    # gen_result = eli5.generate()
-    # gen_result_path = eli5.save_result(gen_result)
-    gen_result_path = args.cache_path + "/results/eli5-bm25-Llama-2-7b-chat-hf-vanilla-shot2-ndoc5.json"
-    eval_result = eli5.evaluate(gen_result_path)
+    eli5.init_model(args.model, args.api_key)
+    gen_result = eli5.predict()
+    eli5.evaluate()
+    eli5.save_result()

--- a/benchmarks/ALCE/ELI5/run.py
+++ b/benchmarks/ALCE/ELI5/run.py
@@ -19,5 +19,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     eli5 = ELI5(args)
-    eli5.generate()
-    eli5.evaluate()
+    # gen_result = eli5.generate()
+    # gen_result_path = eli5.save_result(gen_result)
+    gen_result_path = args.cache_path + "/results/eli5-bm25-Llama-2-7b-chat-hf-vanilla-shot2-ndoc5.json"
+    eval_result = eli5.evaluate(gen_result_path)

--- a/benchmarks/ALCE/ELI5/run.sh
+++ b/benchmarks/ALCE/ELI5/run.sh
@@ -10,4 +10,4 @@ python3 $script_dir/run.py\
   --method vanilla\
   --ndoc 5\
   --shot 2\
-  --metrics nli_claim citation_recall citation_precision
+  --metrics nli_claim citation_recall citation_precision\

--- a/benchmarks/ALCE/ELI5/run.sh
+++ b/benchmarks/ALCE/ELI5/run.sh
@@ -1,0 +1,13 @@
+script_dir=$(cd $(dirname $0);pwd)
+cache_dir=$(dirname $(dirname $(dirname $script_dir)))/.rageval
+wget -cP $cache_dir/datasets https://huggingface.co/datasets/princeton-nlp/ALCE-data/resolve/main/ALCE-data.tar
+tar -xvf $cache_dir/datasets/ALCE-data.tar -C $cache_dir/datasets
+python3 setup.py install
+python3 $script_dir/run.py\
+  --cache_path $cache_dir\
+  --model $cache_dir/models/Llama-2-7b-chat-hf\
+  --dataset bm25\
+  --method vanilla\
+  --ndoc 5\
+  --shot 2\
+  --metrics nli_claim citation_recall citation_precision

--- a/benchmarks/ALCE/ELI5/utils.py
+++ b/benchmarks/ALCE/ELI5/utils.py
@@ -1,7 +1,7 @@
 import json
 
 
-def make_doc_prompt(doc, doc_id, doc_prompt, method=None):
+def make_doc_prompt(doc, doc_id, doc_prompt, method):
     # For doc prompt:
     # - {ID}: doc id (starting from 1)
     # - {T}: title
@@ -19,7 +19,7 @@ def make_doc_prompt(doc, doc_id, doc_prompt, method=None):
     return doc_prompt.replace("{T}", doc["title"]).replace("{P}", text).replace("{ID}", str(doc_id+1))
 
 
-def make_demo(item, prompt, ndoc=None, doc_prompt=None, instruction=None, method=None, test=False):
+def make_demo(item, prompt, ndoc, doc_prompt, instruction, method, test=False):
     # For demo prompt
     # - {INST}: the instruction
     # - {D}: the documents
@@ -49,8 +49,8 @@ def make_demo(item, prompt, ndoc=None, doc_prompt=None, instruction=None, method
     return prompt, doc_texts
 
 
-def create_eli5_eval_dataset(result_path):
-    eval_data = json.load(open(result_path, "r"))
+def create_eli5_eval_dataset(gen_result_path):
+    eval_data = json.load(open(gen_result_path, "r"))
     for data in eval_data:
         yield {
             "question": data["question"],

--- a/benchmarks/ALCE/ELI5/utils.py
+++ b/benchmarks/ALCE/ELI5/utils.py
@@ -1,0 +1,60 @@
+import json
+
+
+def make_doc_prompt(doc, doc_id, doc_prompt, method=None):
+    # For doc prompt:
+    # - {ID}: doc id (starting from 1)
+    # - {T}: title
+    # - {P}: text
+    # use_shorter: None, "summary", or "extraction"
+
+    if method == "vanilla":
+        text = doc['text']
+    elif method == "summary":
+        text = doc["summary"]
+    elif method == "snippet":
+        text = doc["extraction"]
+    else:
+        raise ValueError("Don't support such method.")
+    return doc_prompt.replace("{T}", doc["title"]).replace("{P}", text).replace("{ID}", str(doc_id+1))
+
+
+def make_demo(item, prompt, ndoc=None, doc_prompt=None, instruction=None, method=None, test=False):
+    # For demo prompt
+    # - {INST}: the instruction
+    # - {D}: the documents
+    # - {Q}: the question
+    # - {A}: the answers
+    # ndoc: number of documents to put in context
+    # use_shorter: None, "summary", or "extraction"
+
+    prompt = prompt.replace("{INST}", instruction).replace("{Q}", item['question'])
+    doc_texts = []
+    if "{D}" in prompt:
+        if ndoc == 0:
+            prompt = prompt.replace("{D}\n", "")  # if there is no doc we also delete the empty line
+        else:
+            doc_list = item["docs"][:ndoc]
+            for doc_id, doc in enumerate(doc_list):
+                doc_texts.append(make_doc_prompt(doc, doc_id, doc_prompt, method=method))
+            text = "".join(doc_texts)
+            prompt = prompt.replace("{D}", text)
+
+    if not test:
+        answer = "\n" + "\n".join(item["answer"]) if isinstance(item["answer"], list) else item["answer"]
+        prompt = prompt.replace("{A}", "").rstrip() + answer
+    else:
+        prompt = prompt.replace("{A}", "").rstrip()  # remove any space or \n
+
+    return prompt, doc_texts
+
+
+def create_eli5_eval_dataset(result_path):
+    eval_data = json.load(open(result_path, "r"))
+    for data in eval_data:
+        yield {
+            "question": data["question"],
+            "contexts": data["contexts"],
+            "answers": data["output"],
+            "gt_answers": data["claims"]
+        }

--- a/rageval/metrics/__init__.py
+++ b/rageval/metrics/__init__.py
@@ -1,9 +1,9 @@
 from .base import Metric, MetricWithLLM, add_attribute
-from ._context_recall import ContextRecall
-from ._answer_rouge_correctness import AnswerRougeCorrectness
-from ._context_reject_rate import ContextRejectRate
-from ._answer_exact_match import AnswerEMCorrectness
-from ._answer_claim_recall import AnswerNLICorrectness
-from ._answer_citation_recall import AnswerCitationRecall
 from ._answer_citation_precision import AnswerCitationPrecision
+from ._answer_citation_recall import AnswerCitationRecall
+from ._answer_claim_recall import AnswerNLICorrectness
 from ._answer_disambig_f1 import AnswerDisambigF1Correctness
+from ._answer_exact_match import AnswerEMCorrectness
+from ._answer_rouge_correctness import AnswerRougeCorrectness
+from ._context_recall import ContextRecall
+from ._context_reject_rate import ContextRejectRate

--- a/rageval/metrics/_answer_claim_recall.py
+++ b/rageval/metrics/_answer_claim_recall.py
@@ -3,6 +3,7 @@ from typing import List, Callable
 
 import datasets
 import numpy as np
+from tqdm import tqdm
 
 from rageval.metrics import Metric, add_attribute
 from rageval.utils.check_utils import text_to_sents
@@ -172,7 +173,6 @@ class AnswerNLICorrectness(Metric):
         answers = dataset["answers"]
 
         results = []
-        from tqdm import tqdm
         for i, answer in tqdm(enumerate(answers)):
             r = self._compute_one(answer, claims[i])
             results.append(r)

--- a/rageval/models/nli.py
+++ b/rageval/models/nli.py
@@ -13,7 +13,7 @@ class NLIModel(ABC):
     def __init__(self, task: str = "sentiment-analysis", model: str = "roberta-large-mnli") -> None:
         """Init the Roberta Model."""
         self._model_name = model
-        self._model = pipeline(task=task, model=model)
+        self._model = pipeline(task=task, model=model, device_map="auto")
 
         self._labelmap = {
             "NEUTRAL": 3,
@@ -70,3 +70,13 @@ class NLIModel(ABC):
                 "LABEL_1": "support"
             }
             return nli2stance[pred[0]['label']]
+
+    @pytest.mark.api
+    def generate_infer(self, premise, hypothesis):
+        """Predict one sample with NLI model."""
+        input_text = "premise: {} hypothesis: {}".format(premise, hypothesis)
+        pred = self._model(input_text, max_new_tokens=10)
+        # [{'generated_text': 'support'}]
+        if pred[0]["generated_text"] == "1":
+            return 1
+        return 0

--- a/rageval/utils/check_utils.py
+++ b/rageval/utils/check_utils.py
@@ -10,6 +10,7 @@ from .prompt import DOC_TO_SENTENCES_PROMPT
 logger = logging.getLogger(__name__)
 nltk.download('punkt')
 
+
 def text_to_sents(text: str, model_name="nltk") -> List[str]:
     """Convert the text into a set of sentences."""
     sentences = []

--- a/rageval/utils/check_utils.py
+++ b/rageval/utils/check_utils.py
@@ -14,7 +14,7 @@ def text_to_sents(text: str, model_name="nltk") -> List[str]:
     """Convert the text into a set of sentences."""
     sentences = []
     if model_name == "nltk":
-        nltk.download('punkt')
+        # nltk.download('punkt')
         sentences = nltk.sent_tokenize(text)
         sentences = [s.strip() for s in sentences if len(s.strip()) >= 3]
 

--- a/rageval/utils/check_utils.py
+++ b/rageval/utils/check_utils.py
@@ -8,13 +8,12 @@ from rageval.models import OpenAILLM
 from .prompt import DOC_TO_SENTENCES_PROMPT
 
 logger = logging.getLogger(__name__)
-
+nltk.download('punkt')
 
 def text_to_sents(text: str, model_name="nltk") -> List[str]:
     """Convert the text into a set of sentences."""
     sentences = []
     if model_name == "nltk":
-        # nltk.download('punkt')
         sentences = nltk.sent_tokenize(text)
         sentences = [s.strip() for s in sentences if len(s.strip()) >= 3]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,4 +18,7 @@ pandas == 2.0.0
 nltk == 3.8.1
 spacy == 3.7.4
 en_core_web_sm @ https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.7.1/en_core_web_sm-3.7.1-py3-none-any.whl
-rouge_score == 0.1.2 
+rouge_score == 0.1.2
+accelerate == 0.27.2
+sentencepiece == 0.2.0
+protobuf == 4.25.3

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,10 @@ install_requires = [
     'transformers == 4.37.2',
     'torch == 2.2.0',
     'pandas == 2.0.0',
-    'nltk == 3.8.1'
+    'nltk == 3.8.1',
+    'spacy == 3.7.4',
+    'en_core_web_sm @ https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.7.1/en_core_web_sm-3.7.1-py3-none-any.whl',
+    'rouge_score == 0.1.2'
 ]
 
 extras_requires = {
@@ -38,7 +41,13 @@ extras_requires = {
         'pytest-cov >= 2.4.0',
         'flake8 == 7.0.0',
         'pydocstyle == 2.1',
-        'flake8_docstrings >= 1.7.0'],
+        'flake8_docstrings >= 1.7.0'
+    ],
+    'benchmarks': [
+        'accelerate == 0.27.2',
+        'sentencepiece == 0.2.0',
+        'protobuf == 4.25.3'
+    ]
 }
 
 
@@ -47,7 +56,7 @@ setup(
     version=__version__,
     author="Wenshan Wang, Yixing Fan, etc.",
     author_email="wangwenshan@ict.ac.cn",
-    description=(short_description),
+    description=short_description,
     license="Apache 2.0",
     keywords="RAG evaluation tools",
     url="https://github.com/gomate-community/rageval",

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -58,8 +58,8 @@ def test_evaluation():
         ]
     )
     ag_model = NLIModel(
-        'text-classification',
-        'hf-internal-testing/tiny-random-RobertaPreLayerNormForSequenceClassification'
+        'text2text-generation',
+        'hf-internal-testing/tiny-random-T5ForConditionalGeneration'
     )
 
     # define metrics

--- a/tests/units/test_answer_citation_precision.py
+++ b/tests/units/test_answer_citation_precision.py
@@ -54,8 +54,8 @@ def testset(sample):
 @pytest.mark.slow
 def test_answer_citation_recall(testset):
     nli_model = NLIModel(
-        'text-classification',
-        'hf-internal-testing/tiny-random-RobertaPreLayerNormForSequenceClassification'
+        'text2text-generation',
+        'hf-internal-testing/tiny-random-T5ForConditionalGeneration'
     )
     metric = AnswerCitationPrecision(nli_model=nli_model)
     assert metric.name == "answer_citation_precision"

--- a/tests/units/test_answer_citation_recall.py
+++ b/tests/units/test_answer_citation_recall.py
@@ -54,8 +54,8 @@ def testset(sample):
 @pytest.mark.slow
 def test_answer_citation_recall(testset):
     nli_model = NLIModel(
-        'text-classification',
-        'hf-internal-testing/tiny-random-RobertaPreLayerNormForSequenceClassification'
+        'text2text-generation',
+        'hf-internal-testing/tiny-random-T5ForConditionalGeneration'
     )
     metric = AnswerCitationRecall(nli_model=nli_model)
     assert metric.name == "answer_citation_recall"

--- a/tests/units/test_answer_claim_recall.py
+++ b/tests/units/test_answer_claim_recall.py
@@ -62,8 +62,8 @@ def testset_with_decompose(sample_with_decompose):
 @pytest.mark.slow
 def test_case_on_answer_claim_recall_metric(testset):
     nli_model = NLIModel(
-        'text-classification',
-        'hf-internal-testing/tiny-random-RobertaPreLayerNormForSequenceClassification'
+        'text2text-generation',
+        'hf-internal-testing/tiny-random-T5ForConditionalGeneration'
     )
     metric = AnswerNLICorrectness(nli_model=nli_model)
     assert metric.name == "answer_claim_recall"
@@ -77,8 +77,8 @@ def test_case_on_answer_claim_recall_metric(testset):
 @pytest.mark.slow
 def test_case_on_answer_claim_recall_metric_with_decompose(testset_with_decompose):
     nli_model = NLIModel(
-        'text-classification',
-        'hf-internal-testing/tiny-random-RobertaPreLayerNormForSequenceClassification'
+        'text2text-generation',
+        'hf-internal-testing/tiny-random-T5ForConditionalGeneration'
     )
     metric = AnswerNLICorrectness(nli_model=nli_model, decompose_model="nltk")
     assert metric.name == "answer_claim_recall"


### PR DESCRIPTION
In this PR, the ELI5 benchmark is implemented mainly based on ALCE repo.

- Support both openai api and local LLM now
- Add cache directory `.rageval`
![image](https://github.com/gomate-community/rageval/assets/54350492/08fed808-680b-4e69-854e-f9b9d238383a)
Among them, `datasets` are used to store original data sets, `models` are used to store local LLM, NLI and other models, and `results` are used to store results generated by the RAG system.
During the evaluation phase, users can evaluate directly after generating results or evaluate past results files.
  ```
  eli5 = ELI5(args)
  eli5.generate()
  eli5.evaluate()
  ```
  or
  ```
  eli5 = ELI5(args)
  eli5.result_path = ".rageval/results/eli5-bm25-Llama-2-7b-chat-hf-vanilla-shot2-ndoc5.json"
  eli5.evaluate()
  ```
- Some code in the NLI part has been slightly modified, since more NLI models are generation models rather than classification models, and now support the text2text-generation task. And NLI models are now supported for computing on GPUs now.
- We have now obtained the results of the VANILLA method of llama2-7b-chat on the ELI5 dataset. The `claim recall` metric and the `citation recall` metric are consistent with the data in the paper. The `citation precision` metric looks a little abnormally high. I will check and try to fix it. In addition, the results of gpt-3.5-turbo will also be uploaded later.
  ```
  {
      "nli_claim": 11.5,
      "citation_recall": 26.623809523809523,
      "citation_precision": 74.54545454545455
  }
  ```

In addition, during the test, it was found that the evaluation process was very slow and the user experience was not good. It will be necessary to support parallel computing for these metrics in later work.
